### PR TITLE
Sort by default from oldest to newest and allow toggle

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "RSS-Aggregator",
-  "version": "0.0.3alpha",
+  "version": "0.0.4alpha",
   "description": "Aggregate RSS feeds from the bookmarks and display them on one page",
   "author": "LoveIsGrief",
   "applications": {

--- a/src/aggregator.html
+++ b/src/aggregator.html
@@ -23,16 +23,26 @@
                 <input
                     type="checkbox" id="hideRead"
                     ng-checked="aggregator.hideRead"
-                    ng-click="aggregator.toggleHideRead()"
+                    ng-model="aggregator.hideRead"
                 >
                 Hide read
+            </label>
+        </div>
+        <div class="checkbox">
+            <label>
+                <input
+                    type="checkbox" id="reverseSort"
+                    ng-checked="aggregator.newestToOldest"
+                    ng-model="aggregator.newestToOldest"
+                >
+                Newest to oldest
             </label>
         </div>
     </form>
     <item-detail
         ng-repeat="item in aggregator.items
         | filter:aggregator.hideItemFilter
-        | orderBy: 'datetime'
+        | orderBy: 'datetime' : aggregator.newestToOldest
         track by item.url"
         item="item"
         on-toggle-read="aggregator.toggleRead(item, read)"

--- a/src/angular/aggregator.js
+++ b/src/angular/aggregator.js
@@ -1,19 +1,28 @@
 const DB_KEY = "aggregated-rss";
 
 
-angular.module("aggregatorApp", [
-]).controller("AggregatorController", [
+angular.module("aggregatorApp", []).controller("AggregatorController", [
     "$scope",
     function ($scope) {
         this.dbItems = {};
         this.items = [];
         this.hideRead = false;
+        this.newestToOldest = false;
 
-        browser.storage.sync.get("hideRead").then(({hideRead}) => {
-            $scope.$apply(() => {
-                this.hideRead = hideRead
+        ["hideRead", "newestToOldest"].forEach((booleanOption) => {
+            browser.storage.sync.get(booleanOption).then((res) => {
+                let booleanValue = res[booleanOption];
+                $scope.$apply(() => {
+                    this[booleanOption] = booleanValue;
+                })
+                $scope.$watch(() => this[booleanOption], () => {
+                    browser.storage.sync.set({
+                        [booleanOption]: this[booleanOption]
+                    })
+                })
             })
-        })
+        });
+
 
         setInterval(() => {
             browser.storage.sync.get(DB_KEY).then((aggregated) => {
@@ -30,13 +39,6 @@ angular.module("aggregatorApp", [
         this.toggleRead = (item, read) => {
             item.read = read !== undefined ? read : !item.read;
             browser.storage.sync.set({[DB_KEY]: this.dbItems})
-        }
-
-        this.toggleHideRead = () => {
-            this.hideRead = !this.hideRead;
-            browser.storage.sync.set({
-                hideRead: this.hideRead
-            })
         }
 
         /**


### PR DESCRIPTION
Furthermore we use watch expressions to store the values
 of the boolean options. It's just a little cleaner in case we add more.

#7 Allow control of sort order